### PR TITLE
Fix whitespace handling in ReadWords

### DIFF
--- a/FileReader.cs
+++ b/FileReader.cs
@@ -18,7 +18,9 @@ namespace ReadTextFile
         public int ReadWords(string text)   // function for reading each word in text file
         {
             
-            string[] wordsInTextFile = text.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            // Split on any whitespace so that words separated by new lines,
+            // tabs or multiple spaces are counted correctly
+            string[] wordsInTextFile = text.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
             List<string> countWords = (from word in wordsInTextFile select word).ToList();
             return countWords.Count();
         }


### PR DESCRIPTION
## Summary
- split on any whitespace instead of single spaces when counting words

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5db5ca7c832096d38e4c6beecaa7