### PR TITLE
Add MSTest project and multiline word count test

### DIFF
--- a/FileReader.cs
+++ b/FileReader.cs
@@ -17,8 +17,7 @@ namespace ReadTextFile
         }
         public int ReadWords(string text)   // function for reading each word in text file
         {
-            
-            string[] wordsInTextFile = text.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] wordsInTextFile = text.Split(new char[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries);
             List<string> countWords = (from word in wordsInTextFile select word).ToList();
             return countWords.Count();
         }

--- a/README.md
+++ b/README.md
@@ -5,4 +5,15 @@
 			b. Number of words 
 			c. Number of Chars (except comma, fullstop and any other symbols)
 3. Applications should console app and it should run via command line.
-       EX: C:\temp>Application.exe --input "Some.txt" 
+       EX: C:\temp>Application.exe --input "Some.txt"
+
+## Running Tests
+
+1. Build the solution using MSBuild:
+   ```
+   msbuild ReadTextFile.sln
+   ```
+2. Execute the tests with the Visual Studio test runner:
+   ```
+   vstest.console.exe ReadTextFile.Tests\bin\Debug\ReadTextFile.Tests.dll
+   ```

--- a/ReadTextFile.Tests/Properties/AssemblyInfo.cs
+++ b/ReadTextFile.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ReadTextFile.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ReadTextFile.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("E6F4108A-2D39-4EC3-9D08-381E4B0A5F08")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ReadTextFile.Tests/ReadTextFile.Tests.csproj
+++ b/ReadTextFile.Tests/ReadTextFile.Tests.csproj
@@ -1,0 +1,28 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C7A4A55C-D627-4027-96E9-D93ED317C6C7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ReadTextFile.Tests</RootNamespace>
+    <AssemblyName>ReadTextFile.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReadWordsTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ReadTextFile.csproj">
+      <Project>{C5927270-72EA-48C3-8A59-2DAC2106C008}</Project>
+      <Name>ReadTextFile</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/ReadTextFile.Tests/ReadWordsTests.cs
+++ b/ReadTextFile.Tests/ReadWordsTests.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ReadTextFile.Tests
+{
+    [TestClass]
+    public class ReadWordsTests
+    {
+        [TestMethod]
+        public void ReadWords_MultiLineInput_ReturnsCorrectCount()
+        {
+            var fileReader = new ReadTextFile.FileReader();
+            string text = "Hello world\nThis is a test";
+            int count = fileReader.ReadWords(text);
+            Assert.AreEqual(6, count);
+        }
+    }
+}

--- a/ReadTextFile.sln
+++ b/ReadTextFile.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 15.0.28307.960
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadTextFile", "ReadTextFile\ReadTextFile.csproj", "{C5927270-72EA-48C3-8A59-2DAC2106C008}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadTextFile.Tests", "ReadTextFile.Tests\ReadTextFile.Tests.csproj", "{C7A4A55C-D627-4027-96E9-D93ED317C6C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C5927270-72EA-48C3-8A59-2DAC2106C008}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C5927270-72EA-48C3-8A59-2DAC2106C008}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C5927270-72EA-48C3-8A59-2DAC2106C008}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C5927270-72EA-48C3-8A59-2DAC2106C008}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {C5927270-72EA-48C3-8A59-2DAC2106C008}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C5927270-72EA-48C3-8A59-2DAC2106C008}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C5927270-72EA-48C3-8A59-2DAC2106C008}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C5927270-72EA-48C3-8A59-2DAC2106C008}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C7A4A55C-D627-4027-96E9-D93ED317C6C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C7A4A55C-D627-4027-96E9-D93ED317C6C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C7A4A55C-D627-4027-96E9-D93ED317C6C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C7A4A55C-D627-4027-96E9-D93ED317C6C7}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- fix `ReadWords` so whitespace characters are handled
- add MSTest project with `ReadWords` multiline test
- register the new test project in the solution file
- document how to run the new tests

## Testing
- `msbuild ReadTextFile.sln /t:Build` *(fails: command not found)*
- `vstest.console.exe ReadTextFile.Tests/bin/Debug/ReadTextFile.Tests.dll` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5dbcffac8320817c28015f310aec